### PR TITLE
Fix imports in facebook modules

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from facebook_ad_scraper.facebook_ad_scraper import FacebookAdScraper
+from facebook_ad_scraper import FacebookAdScraper
 
 
 def main():

--- a/facebook_ad_scraper.py
+++ b/facebook_ad_scraper.py
@@ -9,7 +9,7 @@ import tldextract
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 
-from .utils import extract_base_domain, create_session, utc_zone, cst_zone
+from utils import extract_base_domain, create_session, utc_zone, cst_zone
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 global_set = set()


### PR DESCRIPTION
## Summary
- fix import path for FacebookAdScraper in `facebook.py`
- update utility import path in `facebook_ad_scraper.py`

## Testing
- `python -m py_compile facebook.py facebook_ad_scraper.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6865e2a5142c8333b4331413d4d415b0